### PR TITLE
Add Notion-backed blog pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Notion integration variables
+NOTION_SECRET=your-notion-secret
+NOTION_DATABASE_ID=your-database-id
+

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,0 +1,60 @@
+export interface NotionPost {
+  id: string;
+  title: string;
+  slug: string;
+  date?: string;
+}
+
+const NOTION_SECRET = process.env.NOTION_SECRET;
+const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID;
+
+const headers: Record<string, string> = {
+  Authorization: `Bearer ${NOTION_SECRET}`,
+  'Notion-Version': '2022-06-28',
+  'Content-Type': 'application/json',
+};
+
+export async function getPosts(): Promise<NotionPost[]> {
+  if (!NOTION_SECRET || !NOTION_DATABASE_ID) return [];
+
+  const res = await fetch(`https://api.notion.com/v1/databases/${NOTION_DATABASE_ID}/query`, {
+    method: 'POST',
+    headers,
+  });
+
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.results || []).map((page: any) => ({
+    id: page.id,
+    title: page.properties?.Name?.title?.[0]?.plain_text || 'Untitled',
+    slug: page.properties?.Slug?.rich_text?.[0]?.plain_text || page.id,
+    date: page.properties?.Date?.date?.start,
+  }));
+}
+
+export async function getPostBySlug(slug: string): Promise<{ page: any; blocks: any[] } | null> {
+  if (!NOTION_SECRET || !NOTION_DATABASE_ID) return null;
+
+  const res = await fetch(`https://api.notion.com/v1/databases/${NOTION_DATABASE_ID}/query`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      filter: {
+        property: 'Slug',
+        rich_text: { equals: slug },
+      },
+    }),
+  });
+
+  if (!res.ok) return null;
+  const data = await res.json();
+  const page = data.results?.[0];
+  if (!page) return null;
+
+  const blocksRes = await fetch(`https://api.notion.com/v1/blocks/${page.id}/children?page_size=100`, {
+    headers,
+  });
+  if (!blocksRes.ok) return null;
+  const blocksData = await blocksRes.json();
+  return { page, blocks: blocksData.results || [] };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/pages/articles.tsx
+++ b/pages/articles.tsx
@@ -25,7 +25,7 @@ export default function Articles() {
           <ul className="nav-links">
             <li><a href="/">Home</a></li>
             <li><a href="/#services">Our Expertise</a></li>
-            <li><a href="/articles">Blogs</a></li>
+            <li><a href="/blog">Blogs</a></li>
             <li><a href="/#contact">Contact</a></li>
           </ul>
         </div>

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,0 +1,93 @@
+import Head from 'next/head';
+import { getPostBySlug } from '../../lib/notion';
+import type { GetServerSidePropsContext } from 'next';
+
+interface Props {
+  title: string;
+  blocks: any[];
+}
+
+export default function BlogPost({ title, blocks }: Props) {
+  return (
+    <>
+      <Head>
+        <title>{title} | The Compliers</title>
+        <meta name="description" content={title} />
+      </Head>
+
+      <nav id="navbar">
+        <div className="container">
+          <div className="logo"><a href="/">The Compliers</a></div>
+          <ul className="nav-links">
+            <li><a href="/">Home</a></li>
+            <li><a href="/#services">Our Expertise</a></li>
+            <li><a href="/blog">Blogs</a></li>
+            <li><a href="/#contact">Contact</a></li>
+          </ul>
+        </div>
+      </nav>
+
+      <main className="articles-page">
+        <div className="container">
+          <h1>{title}</h1>
+          {blocks.map((block) => {
+            const key = block.id;
+            switch (block.type) {
+              case 'paragraph':
+                return (
+                  <p key={key}>
+                    {block.paragraph.rich_text.map((t: any) => t.plain_text).join('')}
+                  </p>
+                );
+              case 'heading_1':
+                return (
+                  <h2 key={key}>
+                    {block.heading_1.rich_text.map((t: any) => t.plain_text).join('')}
+                  </h2>
+                );
+              case 'heading_2':
+                return (
+                  <h3 key={key}>
+                    {block.heading_2.rich_text.map((t: any) => t.plain_text).join('')}
+                  </h3>
+                );
+              case 'bulleted_list_item':
+                return (
+                  <li key={key}>
+                    {block.bulleted_list_item.rich_text
+                      .map((t: any) => t.plain_text)
+                      .join('')}
+                  </li>
+                );
+              default:
+                return null;
+            }
+          })}
+        </div>
+      </main>
+
+      <footer>
+        <div className="container footer-content">
+          <ul className="footer-nav">
+            <li><a href="/">Home</a></li>
+            <li><a href="/#services">Our Expertise</a></li>
+            <li><a href="/#contact">Contact</a></li>
+            <li><a href="/terms">Terms of Use</a></li>
+            <li><a href="/privacy">Privacy Policy</a></li>
+          </ul>
+        </div>
+      </footer>
+    </>
+  );
+}
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const slug = context.params?.slug as string;
+  const data = await getPostBySlug(slug);
+  if (!data) {
+    return { notFound: true };
+  }
+  const title =
+    data.page.properties?.Name?.title?.[0]?.plain_text || 'Blog Post';
+  return { props: { title, blocks: data.blocks } };
+}

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,13 +1,19 @@
 import Head from 'next/head';
+import Link from 'next/link';
+import { getPosts, NotionPost } from '../../lib/notion';
 
-export default function Terms() {
+interface Props {
+  posts: NotionPost[];
+}
+
+export default function BlogIndex({ posts }: Props) {
   return (
     <>
       <Head>
-        <title>Terms of Use | The Compliers</title>
-        <meta name="description" content="Review the Terms of Use for The Compliers." />
+        <title>Blog | The Compliers</title>
+        <meta name="description" content="Latest insights from The Compliers." />
       </Head>
-      {/* Site Navigation */}
+
       <nav id="navbar">
         <div className="container">
           <div className="logo"><a href="/">The Compliers</a></div>
@@ -19,18 +25,21 @@ export default function Terms() {
           </ul>
         </div>
       </nav>
-      {/* Main content */}
-      <main className="legal-page">
+
+      <main className="articles-page">
         <div className="container">
-          <h1>Terms of Use</h1>
-          <p>These terms govern your use of The Compliers’ website and services. By accessing or using our site, you agree to be bound by these terms. Please read them carefully.</p>
-          <h2>Use of the Site</h2>
-          <p>You agree to use the site for lawful purposes only and in a manner that does not infringe the rights of or restrict the use of the site by any third party.</p>
-          <h2>Intellectual Property</h2>
-          <p>All content on this site is the property of The Compliers or its licensors. Unauthorized reproduction or redistribution is prohibited.</p>
+          <h1>Blog</h1>
+          {posts.length === 0 && <p>No posts found.</p>}
+          <ul>
+            {posts.map((post) => (
+              <li key={post.id}>
+                <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+              </li>
+            ))}
+          </ul>
         </div>
       </main>
-      {/* Footer */}
+
       <footer>
         <div className="container footer-content">
           <ul className="footer-nav">
@@ -44,4 +53,9 @@ export default function Terms() {
       </footer>
     </>
   );
+}
+
+export async function getServerSideProps() {
+  const posts = await getPosts();
+  return { props: { posts } };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,7 +43,7 @@ export default function Home() {
           <ul className="nav-links">
             <li><a href="/">Home</a></li>
             <li><a href="/#services">Our Expertise</a></li>
-            <li><a href="/articles">Blogs</a></li>
+            <li><a href="/blog">Blogs</a></li>
             <li><a href="/#contact">Contact</a></li>
           </ul>
         </div>
@@ -64,7 +64,7 @@ export default function Home() {
           </span>
           <div className="hero-buttons">
             <a href="/#contact" className="btn">Need Help</a>
-            <a href="/articles" className="btn btn-secondary">Learning Center</a>
+            <a href="/blog" className="btn btn-secondary">Learning Center</a>
           </div>
         </div>
       </header>

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -14,7 +14,7 @@ export default function Privacy() {
           <ul className="nav-links">
             <li><a href="/">Home</a></li>
             <li><a href="/#services">Our Expertise</a></li>
-            <li><a href="/articles">Blogs</a></li>
+            <li><a href="/blog">Blogs</a></li>
             <li><a href="/#contact">Contact</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- document Notion env vars
- add Notion helper for fetching posts
- create blog listing and post pages backed by Notion
- update navigation to link to new blog
- switch to NOTION_SECRET env var and document token

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive setup)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfd7e13e34832cb936d968fd98e762