### PR TITLE
feat: add Notion fetch body and logging

### DIFF
--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,0 +1,20 @@
+const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID;
+const NOTION_SECRET = process.env.NOTION_SECRET;
+
+export async function getPosts() {
+  const res = await fetch(`https://api.notion.com/v1/databases/${NOTION_DATABASE_ID}/query`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${NOTION_SECRET}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': '2022-06-28'
+    },
+    body: JSON.stringify({})
+  });
+
+  if (!res.ok) {
+    console.error(`Notion API request failed with status ${res.status}: ${res.statusText}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `body: JSON.stringify({})` to Notion posts fetch
- log non-OK responses for easier debugging

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfe8293848832cbb313ba1fcbc0c01