### PR TITLE
Document Notion env variables and use NOTION_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Compliers Next
+
+This Next.js project uses Notion as a data source. Configure the following environment variables before running or deploying the app:
+
+```
+NOTION_SECRET=<your integration secret>
+NOTION_DATABASE_ID=<database id>
+```
+
+Create a `.env.local` file in the project root or set the variables in your deployment environment so they are available at build and runtime.
+
+## Development
+
+Install dependencies and start the development server:
+
+```
+npm install
+npm run dev
+```

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,7 +1,8 @@
 // lib/notion.ts
 import { Client } from "@notionhq/client";
 
-export const notion = new Client({ auth: process.env.NOTION_TOKEN });
+// NOTION_SECRET and NOTION_DATABASE_ID should be set in the environment
+export const notion = new Client({ auth: process.env.NOTION_SECRET });
 export const databaseId = process.env.NOTION_DATABASE_ID!;
 
 export type BlogPost = {


### PR DESCRIPTION
## Summary
- Switch Notion client to use `NOTION_SECRET` and document required env vars
- Add README outlining setup of `NOTION_SECRET` and `NOTION_DATABASE_ID`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c01686d8e4832cb4dbd20bcd9ce9e9