### PR TITLE
Restore Notion SDK integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Compliers Next.js Blog
+
+This project is a simple Next.js blog powered by Notion.
+
+## Environment Variables
+
+Create a `.env.local` file with the following variables:
+
+```
+NOTION_SECRET=<your-notion-integration-secret>
+NOTION_DATABASE_ID=<your-notion-database-id>
+```
+
+`NOTION_SECRET` may also be provided as `NOTION_TOKEN` for backwards compatibility.
+

--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -1,7 +1,9 @@
 // lib/notion.ts
 import { Client } from "@notionhq/client";
 
-export const notion = new Client({ auth: process.env.NOTION_TOKEN });
+// Support both legacy NOTION_TOKEN and the recommended NOTION_SECRET
+const authToken = process.env.NOTION_SECRET || process.env.NOTION_TOKEN;
+export const notion = new Client({ auth: authToken });
 export const databaseId = process.env.NOTION_DATABASE_ID!;
 
 export type BlogPost = {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "13.5.11",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@notionhq/client": "^2.2.11"
   },
   "devDependencies": {
     "typescript": "5.2.2",


### PR DESCRIPTION
## Summary
- Reinstate Notion SDK usage with support for NOTION_SECRET/NOTION_TOKEN and database queries
- Document Notion environment variables
- Declare `@notionhq/client` dependency

## Testing
- `npm install @notionhq/client` *(fails: 403 Forbidden)*
- `npm run build` *(fails: blog/page.tsx doesn't have a root layout)*

------
https://chatgpt.com/codex/tasks/task_e_68c1534b14d0832ca9e7a07ed7bd86f3