### PR TITLE
Refine blog list navigation and layout

### DIFF
--- a/app/blog/BlogList.tsx
+++ b/app/blog/BlogList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import type { BlogPost } from '@/lib/notion';
 import styles from './blog.module.css';
 
@@ -11,8 +12,6 @@ function formatDate(date?: string) {
 export default function BlogList({ posts }: { posts: BlogPost[] }) {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const [activePost, setActivePost] = useState<BlogPost | null>(null);
-
   const categories = Array.from(new Set(posts.flatMap(p => p.categories)));
   const tags = Array.from(new Set(posts.flatMap(p => p.tags)));
 
@@ -63,47 +62,51 @@ export default function BlogList({ posts }: { posts: BlogPost[] }) {
       </div>
 
       <ul className={styles.postList}>
-        {filtered.map(p => (
-          <li key={p.id} className={styles.postItem}>
-            <h2>
-              <button className={styles.titleButton} onClick={() => setActivePost(p)}>
-                {p.title}
-              </button>
-            </h2>
-            <div className={styles.meta}>
-              {p.publishDate && <span>{formatDate(p.publishDate)}</span>}
-              {p.categories.length > 0 && (
-                <span className={styles.categories}> | {p.categories.join(', ')}</span>
-              )}
-              {p.tags.length > 0 && (
-                <span className={styles.tags}> | {p.tags.join(', ')}</span>
-              )}
-            </div>
-            {p.excerpt && <p className={styles.excerpt}>{p.excerpt}</p>}
-          </li>
-        ))}
-      </ul>
+        {filtered.map(p => {
+          const hasSlug = Boolean(p.slug);
 
-      {activePost && (
-        <div className={styles.modalOverlay} onClick={() => setActivePost(null)}>
-          <div className={styles.modal} onClick={e => e.stopPropagation()}>
-            <button className={styles.closeButton} onClick={() => setActivePost(null)}>
-              &times;
-            </button>
-            <h2>{activePost.title}</h2>
-            <div className={styles.meta}>
-              {activePost.publishDate && <span>{formatDate(activePost.publishDate)}</span>}
-              {activePost.categories.length > 0 && (
-                <span className={styles.categories}> | {activePost.categories.join(', ')}</span>
+          const content = (
+            <>
+              <div>
+                <h2 className={styles.postTitle}>{p.title}</h2>
+                <div className={styles.meta}>
+                  {p.publishDate && <span>{formatDate(p.publishDate)}</span>}
+                  {p.categories.length > 0 && (
+                    <span className={styles.categories}>{p.categories.join(', ')}</span>
+                  )}
+                  {p.tags.length > 0 && (
+                    <span className={styles.tags}>
+                      {p.tags.map(tag => (
+                        <span key={tag} className={styles.tagItem}>
+                          #{tag}
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                </div>
+                {p.excerpt && <p className={styles.excerpt}>{p.excerpt}</p>}
+              </div>
+              <span className={styles.readMore} aria-hidden="true">
+                Read more →
+              </span>
+            </>
+          );
+
+          return (
+            <li key={p.id} className={styles.postItem}>
+              {hasSlug ? (
+                <Link href={`/blog/${p.slug}`} className={styles.postContent}>
+                  {content}
+                </Link>
+              ) : (
+                <div className={`${styles.postContent} ${styles.postContentDisabled}`} aria-disabled>
+                  {content}
+                </div>
               )}
-              {activePost.tags.length > 0 && (
-                <span className={styles.tags}> | {activePost.tags.join(', ')}</span>
-              )}
-            </div>
-            {activePost.text && <p>{activePost.text}</p>}
-          </div>
-        </div>
-      )}
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/app/blog/blog.module.css
+++ b/app/blog/blog.module.css
@@ -1,14 +1,14 @@
 .container {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 0 1rem;
+  max-width: 1080px;
+  margin: 3rem auto 4rem;
+  padding: 0 clamp(1rem, 4vw, 2.5rem);
 }
 
 .filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
 }
 
 .filterGroup {
@@ -16,93 +16,156 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #f1f5f9;
+  border-radius: 9999px;
 }
 
 .filterGroup span {
   font-weight: 600;
+  font-size: 0.9rem;
+  color: #0f172a;
 }
 
 .filterButton {
-  border: 1px solid #0077cc;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  border: 1px solid transparent;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
   background: #fff;
-  color: #0077cc;
+  color: #0369a1;
   cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.filterButton:hover,
+.filterButton:focus-visible {
+  border-color: #bae6fd;
+  background: #e0f2fe;
+  outline: none;
 }
 
 .active {
-  background: #0077cc;
+  background: #0369a1;
   color: #fff;
+  border-color: #0369a1;
 }
 
 .postList {
   list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .postItem {
-  border-bottom: 1px solid #e0e0e0;
-  padding-bottom: 1rem;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  min-height: 100%;
 }
 
-.titleButton {
-  background: none;
-  border: none;
-  color: #0077cc;
-  font-size: 1.25rem;
-  cursor: pointer;
-  text-align: left;
-  padding: 0;
+.postItem:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+}
+
+.postContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.postContent:focus-visible {
+  outline: 3px solid #bae6fd;
+  outline-offset: 4px;
+}
+
+.postContentDisabled {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.postTitle {
+  margin: 0;
+  font-size: clamp(1.3rem, 2vw, 1.65rem);
+  line-height: 1.2;
+  color: #0f172a;
 }
 
 .meta {
-  font-size: 0.9rem;
-  color: #555;
-  margin-bottom: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  color: #475569;
 }
 
-.categories,
+.meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.categories::before,
+.tags::before {
+  content: '•';
+  color: #cbd5f5;
+  font-size: 0.85rem;
+}
+
 .tags {
-  margin-left: 0.5rem;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
 .excerpt {
-  margin-bottom: 0.5rem;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #1f2937;
 }
 
-.modalOverlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
+.tagItem {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  z-index: 1000;
+  padding: 0.15rem 0.6rem;
+  border-radius: 9999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.82rem;
+  font-weight: 500;
+  line-height: 1.4;
 }
 
-.modal {
-  background: #fff;
-  max-width: 800px;
-  width: 90%;
-  max-height: 90vh;
-  overflow: auto;
-  padding: 1rem 1.5rem;
-  border-radius: 8px;
-  position: relative;
+.readMore {
+  font-weight: 600;
+  color: #0369a1;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.closeButton {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
+.postContent:hover .readMore,
+.postContent:focus-visible .readMore {
+  color: #0ea5e9;
+}
+
+@media (max-width: 600px) {
+  .filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filterGroup {
+    justify-content: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
- open individual blog posts by navigating directly to their slugged routes instead of an overlay
- restyle the blog list with card-like spacing, responsive grid, and clearer metadata chips for readability

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ca99e32c0c832c914fb96464fc7b33