### PR TITLE
Scope blog metadata styling to page module

### DIFF
--- a/app/blog/[slug]/blogMeta.module.css
+++ b/app/blog/[slug]/blogMeta.module.css
@@ -1,0 +1,53 @@
+.blogMetaBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 1rem;
+  gap: 0.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #e0edff 0%, #cfe0ff 100%);
+  color: #123066;
+}
+
+.blogMetaItem {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: inherit;
+}
+
+.blogMetaItem + .blogMetaItem::before {
+  content: "|";
+  color: rgba(18, 48, 102, 0.55);
+  margin-right: 0.75rem;
+  margin-left: 0.25rem;
+}
+
+.blogMetaTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.blogMetaPill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(18, 48, 102, 0.25);
+  border-radius: 9999px;
+  padding: 0.15rem 0.6rem;
+  background-color: rgba(255, 255, 255, 0.7);
+  color: inherit;
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.blogMetaPill:hover {
+  background-color: rgba(255, 255, 255, 0.95);
+  border-color: rgba(18, 48, 102, 0.45);
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   getPostBySlug,
   getBlocks, // ensure this exists in lib/notion.ts
 } from "@/lib/notion";
+import styles from "./blogMeta.module.css";
 
 export const revalidate = 3600;
 
@@ -222,40 +223,40 @@ export default async function BlogPost({ params }: { params: { slug: string } })
       <header className="mb-8">
         <h1 className="text-3xl md:text-4xl font-semibold leading-tight">{post.title}</h1>
 
-        <div className="text-sm text-neutral-500 mt-2 flex flex-wrap items-center gap-2">
+        <ul className={styles.blogMetaBar}>
           {post.publishDate && (
-            <time dateTime={post.publishDate}>
-              {new Date(post.publishDate).toLocaleDateString()}
-            </time>
+            <li className={styles.blogMetaItem}>
+              <time dateTime={post.publishDate}>
+                {new Date(post.publishDate).toLocaleDateString()}
+              </time>
+            </li>
           )}
           {post.category && (
-            <>
-              <span>•</span>
+            <li className={styles.blogMetaItem}>
               <Link
                 href={`/blog/category/${encodeURIComponent(post.category)}`}
-                className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs hover:bg-neutral-50"
+                className={styles.blogMetaPill}
               >
                 {post.category}
               </Link>
-            </>
+            </li>
           )}
           {post.tags?.length ? (
-            <>
-              <span>•</span>
-              <span className="flex flex-wrap gap-1">
+            <li className={styles.blogMetaItem}>
+              <span className={styles.blogMetaTags}>
                 {post.tags.map((t: string) => (
                   <Link
                     key={t}
                     href={`/blog/tag/${encodeURIComponent(t)}`}
-                    className="inline-flex items-center rounded-full border bg-neutral-50 px-2 py-0.5 text-xs hover:bg-neutral-100"
+                    className={styles.blogMetaPill}
                   >
                     #{t}
                   </Link>
                 ))}
               </span>
-            </>
+            </li>
           ) : null}
-        </div>
+        </ul>
 
         {post.coverImage && (
           // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION
## Summary
- refactor the blog metadata header to use semantic list markup with module-scoped classes
- move the blue bar, separator, and pill styling into a dedicated CSS module instead of globals

## Testing
- npm run lint *(fails: ESLint is not installed in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68de9e8dd0d4832c9557e3f60f9c2007